### PR TITLE
Add timeout before redirecting user. Add menu button on the nav header

### DIFF
--- a/src/Components/Container/Menu/Menu.jsx
+++ b/src/Components/Container/Menu/Menu.jsx
@@ -20,6 +20,7 @@ class Menu extends Component {
 
   render() {
     const { isLoading, data } = this.props;
+    console.log(this.props);
     return (
       <>
         <LoggedInNavMenu />

--- a/src/Components/View/LoggedInNavMenu/LoggedInNavMenu.jsx
+++ b/src/Components/View/LoggedInNavMenu/LoggedInNavMenu.jsx
@@ -15,7 +15,7 @@ import { logout } from "../../../action/authActions/authActions";
 
 const NavMenu = props => {
   const username = manageUserData.getUsername();
-  const { history, logOutUser } = props;
+  const { history, logOutUser, location } = props;
 
   const handleLogout = e => {
     e.preventDefault();
@@ -34,13 +34,16 @@ const NavMenu = props => {
                   Fast Food Fast
                 </a>
               </li>
+              {location.pathname === "/history" && (
+                <li className="Btn">
+                  <Link to="/menu">Menu</Link>
+                </li>
+              )}
               <li className="Btn">
-                {
-                  <p>
-                    Welcome,
-                    {username}
-                  </p>
-                }
+                <p>
+                  Welcome,
+                  {username}
+                </p>
               </li>
               <li className="Btn">
                 <div className="dropdown">

--- a/src/Components/View/LoggedInNavMenu/LoggedInNavMenu.scss
+++ b/src/Components/View/LoggedInNavMenu/LoggedInNavMenu.scss
@@ -25,7 +25,7 @@ header a {
   color: #ffffff;
   text-decoration: none;
   text-transform: capitalize;
-  font-size: 13px;
+  font-size: 16px;
   display: inline;
 }
 

--- a/src/Components/View/MenuCard/MenuCard.jsx
+++ b/src/Components/View/MenuCard/MenuCard.jsx
@@ -83,7 +83,7 @@ class MenuCard extends Component {
                       className="message"
                       positive
                       onDismiss={this.handleDismiss}
-                      content="Your order has been taken successfully"
+                      content="Your order has been taken successfully. You will be redirected to your order history shortly."
                     />
                   </Container>
                 ) : null}

--- a/src/action/orders/orderActions.js
+++ b/src/action/orders/orderActions.js
@@ -52,7 +52,9 @@ export const postOrder = (orderData, history) => async dispatch => {
       body: orderData
     });
     dispatch(postOrderSuccess(response));
-    setTimeout(history.push("/history"), 2000);
+    setTimeout(() => {
+      history.push("/history");
+    }, 3200);
   } catch (error) {
     dispatch(postOrderFailure(error));
   }


### PR DESCRIPTION
#### What does this PR do?
- Adds a timeout before redirecting the user to the order history page.

#### Description of Task to be completed?
- Adds timeout before redirecting the user. 
- Added menu button on the nav header
#### How should this be manually tested?
 - Clone this repo
- Run `npm install`
- Run `npm run dev` to start the server.
- sign up/sign in with your details
- Navigate to `http://localhost:3500/menu` to view the available menu
- Click on the order button to make an order
- You are redirected to your order history page on completion of successful order
#### What are the relevant pivotal tracker stories?

[Story Title](https://www.pivotaltracker.com/n/projects/2316431/stories/story_id)
